### PR TITLE
Improved travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,6 @@ node_js:
 
 
 before_script:
-
-# display settings for FireFox
-- export DISPLAY=:99.0
-- sh -e /etc/init.d/xvfb start
-
 # install testem & grunt-cli
 - npm install -g testem
 - npm install -g grunt-cli

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,7 @@ language: node_js
 node_js:
 - 0.10
 - 0.8
+
+before_script:
+- npm install -g testem
+- npm install -g grunt-cli

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,13 @@ node_js:
 - 0.10
 - 0.8
 
+
 before_script:
+
+# display settings for FireFox
+- export DISPLAY=:99.0
+- sh -e /etc/init.d/xvfb start
+
+# install testem & grunt-cli
 - npm install -g testem
 - npm install -g grunt-cli

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "project",
   "version": "0.0.1",
   "scripts": {
-    "test": "./node_modules/.bin/grunt"
+    "test": "testem ci"
   },
   "devDependencies": {
     "grunt-contrib-clean": "~0.4.1",
@@ -13,7 +13,6 @@
     "grunt-regarde": "~0.1.1",
     "grunt": "~0.4.1",
     "grunt-exec": "~0.4.1",
-    "grunt-typescript": "~0.2.0",
-    "grunt-cli": "~0.1.9"
+    "grunt-typescript": "~0.2.0"
   }
 }

--- a/testem.json
+++ b/testem.json
@@ -8,5 +8,7 @@
     "serve_files" : [
         "compiled/src/**/*.js",
         "compiled/test/**/*.js"
-    ]
+    ],
+
+    "launch_in_ci": ["PhantomJS"]
 }


### PR DESCRIPTION
- travis 上でちゃんと test run するように修正
- grunt-cli と testem を `bofere_script` で install するように修正
- とりあえず、PhantomJS のみ

---

課題
- Firefox でも test run 自体は出来るけど、test の途中で無反応になって build error になる。(ので、省いています。 https://travis-ci.org/kt3k/monapt/jobs/13526331 )
- PhantomJS の test もなぜか途中で勝手に抜けてる気がする・・・ ( https://travis-ci.org/kt3k/monapt/jobs/13528786 )
